### PR TITLE
Fix preview update

### DIFF
--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -106,7 +106,7 @@ def normalize_movie(movie_path, fps, width, height):
         movflags="+faststart",
         s="%sx%s" % (width, height),
     )
-    stream.run(quiet=False, capture_stderr=True)
+    stream.run(quiet=False, capture_stderr=True, overwrite_output=True)
 
     # Low def version
     low_width = 1280
@@ -130,7 +130,7 @@ def normalize_movie(movie_path, fps, width, height):
         movflags="+faststart",
         s="%sx%s" % (low_width, low_height),
     )
-    stream.run(quiet=False, capture_stderr=True)
+    stream.run(quiet=False, capture_stderr=True, overwrite_output=True)
     return file_target_path, low_file_target_path, err
 
 


### PR DESCRIPTION
**Problem**

Updating a revision through gazu's `update_preview` can lead to "broken" previews.

The logs from *zou* reveal an issue due to the pre-existing file (ffmpeg prompts the user to confirm overwrite).

```
[2021-05-19 17:22:24,265] ERROR in preview_files_service: b"ffmpeg version 4.3-2~16.04.york1 Copyright (c) 2000-2020 the FFmpeg developers\n  built with gcc 5.4.0 (Ubuntu 5.4.0-6ubuntu1~16.04.12) 20160609\n  configuration: --prefix=/usr --extra-version='2~16.04.york1' --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-pocketsphinx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n  libavutil      56. 51.100 / 56. 51.100\n  libavcodec     58. 91.100 / 58. 91.100\n  libavformat    58. 45.100 / 58. 45.100\n  libavdevice    58. 10.100 / 58. 10.100\n  libavfilter     7. 85.100 /  7. 85.100\n  libavresample   4.  0.  0 /  4.  0.  0\n  libswscale      5.  7.100 /  5.  7.100\n  libswresample   3.  7.100 /  3.  7.100\n  libpostproc    55.  7.100 / 55.  7.100\nGuessed Channel Layout for Input Stream #0.1 : stereo\nInput #0, mov,mp4,m4a,3gp,3g2,mj2, from '/tmp/zou/620a72b4-7be3-4bec-b1db-5e7a4f239f87.mov.tmp':\n  Metadata:\n    major_brand     : qt  \n    minor_version   : 537199360\n    compatible_brands: qt  \n    creation_time   : 2021-05-19T13:36:13.000000Z\n  Duration: 00:00:01.60, start: 0.000000, bitrate: 14015 kb/s\n    Stream #0:0(eng): Video: mjpeg (Baseline) (jpeg / 0x6765706A), yuvj422p(pc, bt470bg/unknown/unknown), 960x540 [SAR 72:72 DAR 16:9], 12632 kb/s, 25 fps, 25 tbr, 2500 tbn, 2500 tbc (default)\n    Metadata:\n      creation_time   : 2021-05-19T13:36:13.000000Z\n      handler_name    : Module de gestion vid\xe9o\n      encoder         : Photo - JPEG\n    Stream #0:1(eng): Audio: pcm_s16le (sowt / 0x74776F73), 44100 Hz, stereo, s16, 1411 kb/s (default)\n    Metadata:\n      creation_time   : 2021-05-19T13:36:14.000000Z\n      handler_name    : Module de gestion Son\nPlease use -b:a or -b:v, -b is ambiguous\nFile '/tmp/zou/620a72b4-7be3-4bec-b1db-5e7a4f239f87.mp4' already exists. Overwrite? [y/N] Not overwriting - exiting\n"
```

**Solution**
Change calls to ffmpeg to force overwrite, using the [` overwrite_output` of `ffmpeg.run`](https://github.com/kkroening/ffmpeg-python/blob/f3079726fae7b7b71e4175f79c5eeaddc1d205fb/ffmpeg/_run.py#L302)
